### PR TITLE
Fix hash crash

### DIFF
--- a/softposit.rkt
+++ b/softposit.rkt
@@ -60,7 +60,7 @@
   #:malloc-mode 'atomic-interior)
 (define-cstruct _posit128 ([v (make-array-type _uint64 2)])
   #:property prop:equal+hash
-  (list (λ (x y) (f (posit128-v x) (posit128-v y))) (λ (x f) (f (posit128-v x))) (λ (x f) (f (posit128-v x))))
+  (list (λ (x y f) (f (posit128-v x) (posit128-v y))) (λ (x f) (f (posit128-v x))) (λ (x f) (f (posit128-v x))))
   #:malloc-mode 'atomic-interior)
 
 (define-cstruct _quire8 ([v _uint32]) 
@@ -267,7 +267,7 @@
 
 (define posit16->double (get-ffi-obj "convertP16ToDouble" "libsoftposit" (_fun _posit16 -> _double)))
 (define float->posit16 (get-ffi-obj "convertFloatToP16" "libsoftposit" (_fun _float -> _posit16)))
-(define double->posit16 x
+(define double->posit16
   (let ([fn (get-ffi-obj "convertDoubleToP16" "libsoftposit" (_fun _double -> _posit16))])
     (λ (x) (if (exact? x) (fn (exact->inexact x)) (fn x)))))
 

--- a/softposit.rkt
+++ b/softposit.rkt
@@ -42,15 +42,39 @@
          posit8->ordinal posit16->ordinal posit32->ordinal
          ordinal->posit8 ordinal->posit16 ordinal->posit32)
 
-(define-cstruct _posit8 ([v _uint8]) #:malloc-mode 'atomic-interior)
-(define-cstruct _posit16 ([v _uint16]) #:malloc-mode 'atomic-interior)
-(define-cstruct _posit32 ([v _uint32]) #:malloc-mode 'atomic-interior)
-(define-cstruct _posit64 ([v _uint64]) #:malloc-mode 'atomic-interior)
-(define-cstruct _posit128 ([v (make-array-type _uint64 2)]) #:malloc-mode 'atomic-interior)
+(define-cstruct _posit8 ([v _uint8])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (posit8-v x) (posit8-v y))) (λ (x f) (f (posit8-v x))) (λ (x f) (f (posit8-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _posit16 ([v _uint16])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (posit16-v x) (posit16-v y))) (λ (x f) (f (posit16-v x))) (λ (x f) (f (posit16-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _posit32 ([v _uint32])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (posit32-v x) (posit32-v y))) (λ (x f) (f (posit32-v x))) (λ (x f) (f (posit32-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _posit64 ([v _uint64])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (posit64-v x) (posit64-v y))) (λ (x f) (f (posit64-v x))) (λ (x f) (f (posit64-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _posit128 ([v (make-array-type _uint64 2)])
+  #:property prop:equal+hash
+  (list (λ (x y) (f (posit128-v x) (posit128-v y))) (λ (x f) (f (posit128-v x))) (λ (x f) (f (posit128-v x))))
+  #:malloc-mode 'atomic-interior)
 
-(define-cstruct _quire8 ([v _uint32]) #:malloc-mode 'atomic-interior)
-(define-cstruct _quire16 ([v (make-array-type _uint64 2)]) #:malloc-mode 'atomic-interior)
-(define-cstruct _quire32 ([v (make-array-type _uint64 8)]) #:malloc-mode 'atomic-interior)
+(define-cstruct _quire8 ([v _uint32]) 
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (quire8-v x) (quire8-v y))) (λ (x f) (f (quire8-v x))) (λ (x f) (f (quire8-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _quire16 ([v (make-array-type _uint64 2)])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (quire16-v x) (quire16-v y))) (λ (x f) (f (quire16-v x))) (λ (x f) (f (quire16-v x))))
+  #:malloc-mode 'atomic-interior)
+(define-cstruct _quire32 ([v (make-array-type _uint64 8)])
+  #:property prop:equal+hash
+  (list (λ (x y f) (f (quire32-v x) (quire32-v y))) (λ (x f) (f (quire32-v x))) (λ (x f) (f (quire32-v x))))
+  #:malloc-mode 'atomic-interior)
 
 (define (random-bits b [n 0])
   (if (= b 0)

--- a/softposit.rkt
+++ b/softposit.rkt
@@ -212,11 +212,9 @@
 ;; TODO: isNaRQ8, isQ8Zero, (consider q8Clr), castQ8, castP8, negP8
 
 (define posit8->double (get-ffi-obj "convertP8ToDouble" "libsoftposit" (_fun _posit8 -> _double)))
-(define (double->posit8 x)
-  (define fn (get-ffi-obj "convertDoubleToP8" "libsoftposit" (_fun _double -> _posit8)))
-  (if (exact? x)
-    (fn (exact->inexact x))
-    (fn x)))
+(define double->posit8
+  (let ([fn (get-ffi-obj "convertDoubleToP8" "libsoftposit" (_fun _double -> _posit8))])
+    (λ (x) (if (exact? x) (fn (exact->inexact x)) (fn x)))))
 
 (define posit16->uint32 (get-ffi-obj "p16_to_ui32" "libsoftposit" (_fun _posit16 -> _uint32)))
 (define posit16->uint64 (get-ffi-obj "p16_to_ui64" "libsoftposit" (_fun _posit16 -> _uint64)))
@@ -269,11 +267,9 @@
 
 (define posit16->double (get-ffi-obj "convertP16ToDouble" "libsoftposit" (_fun _posit16 -> _double)))
 (define float->posit16 (get-ffi-obj "convertFloatToP16" "libsoftposit" (_fun _float -> _posit16)))
-(define (double->posit16 x)
-  (define fn (get-ffi-obj "convertDoubleToP16" "libsoftposit" (_fun _double -> _posit16)))
-  (if (exact? x)
-    (fn (exact->inexact x))
-    (fn x)))
+(define double->posit16 x
+  (let ([fn (get-ffi-obj "convertDoubleToP16" "libsoftposit" (_fun _double -> _posit16))])
+    (λ (x) (if (exact? x) (fn (exact->inexact x)) (fn x)))))
 
 (define posit32->uint32 (get-ffi-obj "p32_to_ui32" "libsoftposit" (_fun _posit32 -> _uint32)))
 (define posit32->uint64 (get-ffi-obj "p32_to_ui64" "libsoftposit" (_fun _posit32 -> _uint64)))
@@ -326,11 +322,9 @@
 
 (define posit32->double (get-ffi-obj "convertP32ToDouble" "libsoftposit" (_fun _posit32 -> _double)))
 (define float->posit32 (get-ffi-obj "convertFloatToP32" "libsoftposit" (_fun _float -> _posit32)))
-(define (double->posit32 x)
-  (define fn (get-ffi-obj "convertDoubleToP32" "libsoftposit" (_fun _double -> _posit32)))
-  (if (exact? x)
-    (fn (exact->inexact x))
-    (fn x)))
+(define double->posit32
+  (let ([fn (get-ffi-obj "convertDoubleToP32" "libsoftposit" (_fun _double -> _posit32))])
+    (λ (x) (if (exact? x) (fn (exact->inexact x)) (fn x)))))
 
 (define (posit8->quire8 p) (create-quire8 p))
 (define (posit16->quire16 p) (create-quire16 p))


### PR DESCRIPTION
This adds the `prop:hash+equal` property to all posits, which fixes issues that otherwise come up when using posits as hash keys. The hash is derived from the underlying integer/array used as a field value.